### PR TITLE
url of production

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,7 @@
 {
     "version": 2,
     "name": "React-Notify",
+    "alias": "react-notify",
     "builds": [
       {"src": "package.json", "use": "@now/static-build", "config": {"distDir": "build"}}
     ],


### PR DESCRIPTION
The previous url is not a good idea to use production environments. With the change that I just made the url should be the following: https://react-notify.now.sh 👍 